### PR TITLE
persistent storage

### DIFF
--- a/helm/templates/workflow-pvc.yaml
+++ b/helm/templates/workflow-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-workflow-pvc
+  name: {{ .Values.QGNetWorkflowPVCName }}
   namespace: qgnet
 spec:
   accessModes:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -116,6 +116,3 @@ minio:
   ## defaultBuckets: "my-bucket, my-second-bucket"
   ##
   defaultBuckets: "argo-workflows"
-
-  persistence:
-    existingClaim: qgnet-ogdc-workflow-pvc

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -116,3 +116,6 @@ minio:
   ## defaultBuckets: "my-bucket, my-second-bucket"
   ##
   defaultBuckets: "argo-workflows"
+
+  persistence:
+    existingClaim: qgnet-ogdc-workflow-pvc

--- a/scripts/install-ogdc.sh
+++ b/scripts/install-ogdc.sh
@@ -35,4 +35,4 @@ QGNET_WORKFLOW_PVC_NAME="${RELEASE_NAME}-workflow-pvc"
 echo "Using QGNET_WORKFLOW_PVC_NAME=${QGNET_WORKFLOW_PVC_NAME}"
 
 # `qgnet-ogdc` is the "release name".
-helm install --set ENV="$ENV" --set minio.persistence.existingClaim=$QGNET_WORKFLOW_PVC_NAME --set QGNetWorkflowPVCName="$QGNET_WORKFLOW_PVC_NAME" --set OgdcPVHostPath="$OGDC_PV_HOST_PATH" $RELEASE_NAME "$THIS_DIR/../helm" -n qgnet
+helm install --set ENV="$ENV" --set QGNetWorkflowPVCName="$QGNET_WORKFLOW_PVC_NAME" --set OgdcPVHostPath="$OGDC_PV_HOST_PATH" $RELEASE_NAME "$THIS_DIR/../helm" -n qgnet

--- a/scripts/install-ogdc.sh
+++ b/scripts/install-ogdc.sh
@@ -29,5 +29,10 @@ helm repo add minio https://charts.min.io/
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm dependency build helm/
 
+RELEASE_NAME="qgnet-ogdc"
+echo "Using RELEASE_NAME=${RELEASE_NAME}"
+QGNET_WORKFLOW_PVC_NAME="${RELEASE_NAME}-workflow-pvc"
+echo "Using QGNET_WORKFLOW_PVC_NAME=${QGNET_WORKFLOW_PVC_NAME}"
+
 # `qgnet-ogdc` is the "release name".
-helm install --set ENV="$ENV" --set OgdcPVHostPath="$OGDC_PV_HOST_PATH" qgnet-ogdc "$THIS_DIR/../helm" -n qgnet
+helm install --set ENV="$ENV" --set minio.persistence.existingClaim=$QGNET_WORKFLOW_PVC_NAME --set QGNetWorkflowPVCName="$QGNET_WORKFLOW_PVC_NAME" --set OgdcPVHostPath="$OGDC_PV_HOST_PATH" $RELEASE_NAME "$THIS_DIR/../helm" -n qgnet


### PR DESCRIPTION
Resolves #11 

This PR configures minio, which we use for argo's artifact storage, to use the OGDC PVC.

By default in development, the PVC is host-mounted to the `ogdc-helm` repo's location under `ogdc-local-hostmount/`.

```
$ ogdc-runner submit-and-wait ../ogdc-recipes/recipes/seal-tags/
Successfully submitted recipe with workflow name seal-tags-klnsz
Workflow status: Running
Workflow status: Running
Workflow status: Running
Workflow status: Succeeded
$ tree -d ../ogdc-helm/ogdc-local-hostmount/argo-workflows/
/home/trst2284/code/argo-provision/ogdc-local-hostmount/argo-workflows/
└── seal-tags-klnsz
    ├── seal-tags-klnsz-run-cmd-0-208443041
    │   └── output-dir.tgz
    │       └── 4ebd752b-46a0-4db9-88c6-91e373f21f17
    └── seal-tags-klnsz-seal-tags-fetch-template-2500013348
        └── output-dir.tgz
            └── 799deed7-cbe5-4128-a358-2d429befce70

7 directories
``` 

Note: argo can perform artifact garbage collection (e.g., on workflow deletion), which we should consider implementing so that intermediate data from old workflows get cleaned up automatically. I tried setting this up, but the bitnami helm chart does not appear to expose the option necessary to enable this feature. See https://github.com/QGreenland-Net/ogdc-helm/issues/13