### PR TITLE
Fixup misunderstood values yaml

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,7 +22,7 @@ global:
   ## example, if the release name is 'myrelease', the value of name: would be
   ## 'myrelease-secrets'.
   ##
-  passwordsSecret: &passwordSecretName ${RELEASE_NAME}-secrets
+  passwordsSecret: &passwordSecretName "myrelease-secrets"
 
   ## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
   ##


### PR DESCRIPTION
hard-code default release name in values.yaml

* This file is not pre-processed with `envsubst`, so `${RELEASE_NAME}` never gets
interpolated. It gives the false impression that the `RELEASE_NAME` envvar is
applied here.
* Using `{{ .Release.Name }}` here does not work.
