### PR TITLE
Update service deployment to use prod run cmd in non-local envs

### DIFF
--- a/helm/examples/values-local-cluster-ogdc-example.yaml
+++ b/helm/examples/values-local-cluster-ogdc-example.yaml
@@ -100,3 +100,6 @@ image:
   pullPolicy: Never
 
 environment: "local"
+
+# Use fastapi dev server for local dev
+ogdc_service_command: ". ./.venv/bin/activate && fastapi dev --port 8000 --host 0.0.0.0 src/ogdc_runner/service.py"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       containers:
       - name: ogdc-service
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command:
+          - "bash"
+          - "-c"
+          - "{{ .Values.ogdc_service_command }}"
         ports:
         - containerPort: 8000
           name: ogdc-api-port

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -277,3 +277,6 @@ minio:
 image:
   repository: ogdc-runner
   tag: latest
+
+# Default to production fastapi run command
+ogdc_service_command: ". ./.venv/bin/activate && fastapi run --port 8000 --host 0.0.0.0 src/ogdc_runner/service.py"


### PR DESCRIPTION
Makes the command run for the OGDC service layer configurable via values. In local env, we use the fastapi dev server. In all other envs we will use the production server. 

Component of https://github.com/QGreenland-Net/ogdc-runner/issues/125. See also: https://github.com/QGreenland-Net/ogdc-runner/pull/127