### PR TITLE
OGDC dev deployment v0.3

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -130,7 +130,7 @@ Refer to the [getting started](https://github.com/QGreenland-Net/ogdc-helm?tab=r
 | `dataone_node_url`          | DataONE member node URL for metadata retrieval             | `https://arcticdata.io/metacat/d1/mn`                                                              |
 | `ogdc_public_host`          | Public hostname for OGDC service and ingress configuration | `api.test.dataone.org`                                                                             |
 | `internal_s3_endpoint_url`  | Internal S3 endpoint URL for MinIO service                 | `http://qgnet-ogdc-minio:9000`                                                                     |
-| `public_s3_endpoint_url`    | Public S3 endpoint URL for external access                 | `https://{{ .Values.ogdc_public_host }}/ogdc/storage/`                                             |
+| `public_s3_endpoint_url`    | Public S3 endpoint URL for external access                 | `https://api.test.dataone.org/ogdc/storage/`                                                       |
 | `environment`               | Environment name (dev, prod, local)                        | `dev`                                                                                              |
 
 ### Ingress Configuration

--- a/helm/README.md
+++ b/helm/README.md
@@ -118,11 +118,29 @@ Refer to the [getting started](https://github.com/QGreenland-Net/ogdc-helm?tab=r
 
 ### OGDC Configuration
 
-| Name                       | Description                                    | Value                                                                                              |
-| -------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `image.repository`         | OGDC container image repository                | `ogdc-runner`                                                                                      |
-| `image.tag`                | OGDC container image tag                       | `latest`                                                                                           |
-| `ogdc_service_command`     | Command to start the OGDC FastAPI service      | `. ./.venv/bin/activate && fastapi run --port 8000 --host 0.0.0.0 src/ogdc_runner/service/main.py` |
-| `dataone_node_url`         | DataONE member node URL for metadata retrieval | `https://arcticdata.io/metacat/d1/mn`                                                              |
-| `internal_s3_endpoint_url` | Internal S3 endpoint URL for MinIO service     | `http://qgnet-ogdc-minio:9000`                                                                     |
-| `public_s3_endpoint_url`   | Public S3 endpoint URL for external access     | `http://api.test.dataone.org/ogdc/objectstore/`                                                    |
+| Name                        | Description                                                | Value                                                                                              |
+| --------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `image.repository`          | OGDC container image repository                            | `ogdc-runner`                                                                                      |
+| `image.tag`                 | OGDC container image tag                                   | `latest`                                                                                           |
+| `resources.requests.memory` | Memory requests for OGDC service                           | `1Gi`                                                                                              |
+| `resources.requests.cpu`    | CPU requests for OGDC service                              | `500m`                                                                                             |
+| `resources.limits.memory`   | Memory limits for OGDC service                             | `2Gi`                                                                                              |
+| `resources.limits.cpu`      | CPU limits for OGDC service                                | `1000m`                                                                                            |
+| `ogdc_service_command`      | Command to start the OGDC FastAPI service                  | `. ./.venv/bin/activate && fastapi run --port 8000 --host 0.0.0.0 src/ogdc_runner/service/main.py` |
+| `dataone_node_url`          | DataONE member node URL for metadata retrieval             | `https://arcticdata.io/metacat/d1/mn`                                                              |
+| `ogdc_public_host`          | Public hostname for OGDC service and ingress configuration | `api.test.dataone.org`                                                                             |
+| `internal_s3_endpoint_url`  | Internal S3 endpoint URL for MinIO service                 | `http://qgnet-ogdc-minio:9000`                                                                     |
+| `public_s3_endpoint_url`    | Public S3 endpoint URL for external access                 | `https://{{ .Values.ogdc_public_host }}/ogdc/storage/`                                             |
+| `environment`               | Environment name (dev, prod, local)                        | `dev`                                                                                              |
+
+### Ingress Configuration
+
+| Name                                                             | Description                                                      | Value                    |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| `ingress.enabled`                                                | Enable ingress resource for OGDC                                 | `true`                   |
+| `ingress.className`                                              | IngressClass to use for the ingress resource                     | `nginx`                  |
+| `ingress.annotations.cert-manager.io/cluster-issuer`             | cert-manager ClusterIssuer to use for TLS certificate management | `letsencrypt-prod`       |
+| `ingress.annotations.nginx.ingress.kubernetes.io/rewrite-target` | Rewrite target for nginx ingress                                 | `/$2`                    |
+| `ingress.annotations.nginx.ingress.kubernetes.io/use-regex`      | Use regex for nginx ingress paths                                | `true`                   |
+| `ingress.tls.enabled`                                            | Enable TLS for ingress                                           | `true`                   |
+| `ingress.tls.secretName`                                         | Name of the secret containing TLS certificate                    | `ingress-nginx-tls-cert` |

--- a/helm/examples/values-dev-cluster-ogdc-example.yaml
+++ b/helm/examples/values-dev-cluster-ogdc-example.yaml
@@ -45,54 +45,6 @@ argo-workflows:
     ## https://github.com/argoproj/argo-workflows/issues/716#issuecomment-433213190
     baseHref: /ogdc
 
-    ## Ingress configuration.
-    # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
-    ingress:
-      ## -- Enable an ingress resource
-      ## Enable an ingress resource for the Argo server
-      enabled: false
-      # -- Ingress class name
-      ## Your cluster may require this to be set to match your IngressClass resource.
-      ## For nginx ingress controller, use:  ingressClassName: "nginx"
-      ingressClassName: "nginx"
-      # -- Additional ingress annotations
-      ## Add any additional annotations that your ingress controller may need.
-      ## For example, for cert-manager TLS using the 'letsencrypt-prod' ClusterIssuer
-      ## (which must be created separately), and to specify that the backend protocol
-      ## is HTTPS, use the following annotations:
-      annotations: { 
-        cert-manager.io/cluster-issuer: letsencrypt-prod,
-        nginx.ingress.kubernetes.io/rewrite-target: /$2,
-        nginx.ingress.kubernetes.io/use-regex: "true"
-      }
-      ## -- Ingress hosts
-      ## Add host names (without http(s):// or path) that map to the argo server service.
-      ## You may need to add multiple hosts if you have multiple DNS names that map to the
-      ## same service.
-      hosts:
-        - api.test.dataone.org
-      ## -- Ingress endpoint paths
-      ## If you are using a path other than '/', make sure to also set
-      ## server.baseHref to match!
-      paths:
-        - /ogdc(/|$)(.*)
-      ## -- Path type
-      ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-      pathType: ImplementationSpecific
-      ## -- Ingress service backend configuration
-      ## This is the port for the ogdc service
-      servicePort: 8000
-      ## -- Ingress TLS configuration
-      ## Add TLS configuration for the Ingress, if desired.
-      ## This example assumes you have created a TLS secret named
-      ## 'ingress-nginx-tls-cert' in the same namespace as the argo server.
-      ## The TLS secret must contain the certificate and private key for the host(s)
-      ## specified above.
-      tls:
-        - hosts:
-            - api.test.dataone.org
-          secretName: ingress-nginx-tls-cert
-
   ## Artifact repository configuration## Artifact repository configuration
   artifactRepository:
     s3:
@@ -130,4 +82,8 @@ image:
 environment: "dev"
 
 ogdc_public_host: "api.test.dataone.org"
-ogdc_s3_endpoint: "http://qgnet-ogdc-minio:9000"
+internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
+public_s3_endpoint_url: "https://api.test.dataone.org/ogdc/storage/"
+
+ingress:
+  enabled: true

--- a/helm/examples/values-local-cluster-ogdc-example.yaml
+++ b/helm/examples/values-local-cluster-ogdc-example.yaml
@@ -102,4 +102,4 @@ internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
 public_s3_endpoint_url: "http://localhost:7443/ogdc/storage/"
 
 ingress:
-  enabled: false
+  enabled: true

--- a/helm/examples/values-local-cluster-ogdc-example.yaml
+++ b/helm/examples/values-local-cluster-ogdc-example.yaml
@@ -47,14 +47,6 @@ argo-workflows:
     ## -- Install and upgrade CRDs
     install: true
 
-  ## Argo Server configuration
-  server:
-    ## Ingress configuration.
-    # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
-    ingress:
-      # -- Enable an ingress resource
-      enabled: false
-
   ## Artifact repository configuration
   artifactRepository:
     s3:
@@ -105,5 +97,9 @@ environment: "local"
 ogdc_service_command: ". ./.venv/bin/activate && fastapi dev --port 8000 --host 0.0.0.0 src/ogdc_runner/service/main.py"
 
 
-ogdc_public_host: "localhost:7443"
-ogdc_s3_endpoint: "http://qgnet-ogdc-minio:9000"
+ogdc_public_host: "localhost"
+internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
+public_s3_endpoint_url: "http://localhost:7443/ogdc/storage/"
+
+ingress:
+  enabled: false

--- a/helm/examples/values-prod-cluster-ogdc-example.yaml
+++ b/helm/examples/values-prod-cluster-ogdc-example.yaml
@@ -37,62 +37,6 @@ argo-workflows:
     ## -- Install and upgrade CRDs
     install: false
 
-  ## Argo Server configuration
-  server:
-    ## -- Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /.
-    ## only updates base url of resources on client side,
-    ## it's expected that a proxy server rewrites the request URL and gets rid of this prefix
-    ## https://github.com/argoproj/argo-workflows/issues/716#issuecomment-433213190
-    baseHref: /ogdc
-
-    ## Ingress configuration.
-    # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
-    ingress:
-      ## -- Enable an ingress resource
-      ## Enable an ingress resource for the Argo server
-      enabled: true
-      # -- Ingress class name
-      ## Your cluster may require this to be set to match your IngressClass resource.
-      ## For nginx ingress controller, use:  ingressClassName: "nginx"
-      ingressClassName: "nginx"
-      # -- Additional ingress annotations
-      ## Add any additional annotations that your ingress controller may need.
-      ## For example, for cert-manager TLS using the 'letsencrypt-prod' ClusterIssuer
-      ## (which must be created separately), and to specify that the backend protocol
-      ## is HTTPS, use the following annotations:
-      annotations: { 
-        cert-manager.io/cluster-issuer: letsencrypt-prod,
-        nginx.ingress.kubernetes.io/rewrite-target: /$2,
-        nginx.ingress.kubernetes.io/use-regex: "true"
-      }
-      ## -- Ingress hosts
-      ## Add host names (without http(s):// or path) that map to the argo server service.
-      ## You may need to add multiple hosts if you have multiple DNS names that map to the
-      ## same service.
-      hosts:
-        - api.dataone.org
-      ## -- Ingress endpoint paths
-      ## If you are using a path other than '/', make sure to also set
-      ## server.baseHref to match!
-      paths:
-        - /ogdc(/|$)(.*)
-      ## -- Path type
-      ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-      pathType: ImplementationSpecific
-      ## -- Ingress service backend configuration
-      ## This is the port for the ogdc service
-      servicePort: 8000
-      ## -- Ingress TLS configuration
-      ## Add TLS configuration for the Ingress, if desired.
-      ## This example assumes you have created a TLS secret named
-      ## 'ingress-nginx-tls-cert' in the same namespace as the argo server.
-      ## The TLS secret must contain the certificate and private key for the host(s)
-      ## specified above.
-      tls:
-        - hosts:
-            - api.dataone.org
-          secretName: ingress-nginx-tls-cert
-
   ## Artifact repository configuration## Artifact repository configuration
   artifactRepository:
     s3:
@@ -128,5 +72,9 @@ image:
 environment: "prod"
 
 ogdc_public_host: "api.dataone.org"
-ogdc_s3_endpoint: "http://qgnet-ogdc-minio:9000"
+internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
+public_s3_endpoint_url: "https://api.dataone.org/ogdc/storage/"
 dataone_node_url: "https://arcticdata.io/metacat/d1/mn"
+
+ingress:
+  enabled: true

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -8,6 +8,6 @@ data:
   OGDC_RUNNER_IMAGE_TAG: {{ .Values.image.tag | quote }}
   DATAONE_NODE_URL: {{ .Values.dataone_node_url | quote }}
   ARGO_WORKFLOWS_SERVICE_URL: "http://{{ .Release.Name }}-argo-workflows-server.{{ .Release.Namespace }}.svc.cluster.local:2746"
-  INTERNAL_S3_ENDPOINT_URL: "{{ .Values.ogdc_s3_endpoint }}"
-  PUBLIC_S3_ENDPOINT_URL: "https://{{ .Values.ogdc_public_host }}/ogdc/storage"
+  INTERNAL_S3_ENDPOINT_URL: "{{ .Values.internal_s3_endpoint_url }}"
+  PUBLIC_S3_ENDPOINT_URL: "{{ .Values.public_s3_endpoint_url }}"
   API_ROOT_PATH: "/ogdc/api"

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,24 +1,30 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ogdc-ingress
-  annotations: 
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
+  name: {{ include "ogdc.fullname" . }}-ingress
+  labels:
+    {{- include "ogdc.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
-      - api.dataone.org
-      - api.test.dataone.org
-      - localhost
-    secretName: "ingress-nginx-tls-cert"
-  ingressClassName: "nginx"
+      - {{ .Values.ogdc_public_host | quote }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
   rules:
-  - http:
+  - host: {{ .Values.ogdc_public_host | quote }}
+    http:
       paths:
       - path: /ogdc/api(/|$)(.*)
-        pathType: ImplementationSpecific
+        pathType: Prefix
         backend:
           service:
             name: ogdc-service-service
@@ -27,9 +33,10 @@ spec:
       # TODO: this will need some re-thinking based on how we deal with
       # https://github.com/QGreenland-Net/ogdc-helm/issues/46. 
       - path: /ogdc/storage(/|$)(.*)
-        pathType: ImplementationSpecific
+        pathType: Prefix
         backend:
           service:
             name: qgnet-ogdc-minio
             port:
               number: 9000
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -347,7 +347,7 @@ internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
 
 ## @param public_s3_endpoint_url Public S3 endpoint URL for external access
 ## Uses ogdc_public_host by default
-public_s3_endpoint_url: "https://{{ .Values.ogdc_public_host }}/ogdc/storage/"
+public_s3_endpoint_url: "https://api.test.dataone.org/ogdc/storage/"
 
 ## @param environment Environment name (dev, prod, local)
 environment: "dev"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -314,6 +314,18 @@ image:
   repository: ogdc-runner
   tag: latest
 
+## @param resources.requests.memory Memory requests for OGDC service
+## @param resources.requests.cpu CPU requests for OGDC service
+## @param resources.limits.memory Memory limits for OGDC service
+## @param resources.limits.cpu CPU limits for OGDC service
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+  limits: 
+    memory: "2Gi"
+    cpu: "1000m"
+
 ## @param ogdc_service_command Command to start the OGDC FastAPI service
 ## Default to production fastapi run command
 ##
@@ -322,10 +334,45 @@ ogdc_service_command: ". ./.venv/bin/activate && fastapi run --port 8000 --host 
 ## @param dataone_node_url DataONE member node URL for metadata retrieval
 dataone_node_url: "https://arcticdata.io/metacat/d1/mn"
 
+## @param ogdc_public_host Public hostname for OGDC service and ingress configuration
+## For local development, set to "localhost" and disable ingress
+## For dev cluster, set to "api.test.dataone.org"
+## For prod cluster, set to "api.dataone.org"
+ogdc_public_host: "api.test.dataone.org"
+
 ## @param internal_s3_endpoint_url Internal S3 endpoint URL for MinIO service
-## This is the URL at which the s3 service is exposed at.
+## This is the URL at which the s3 service is exposed at (cluster-internal)
 ##
 internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
 
 ## @param public_s3_endpoint_url Public S3 endpoint URL for external access
-public_s3_endpoint_url: "http://api.test.dataone.org/ogdc/objectstore/"
+## Uses ogdc_public_host by default
+public_s3_endpoint_url: "https://{{ .Values.ogdc_public_host }}/ogdc/storage/"
+
+## @param environment Environment name (dev, prod, local)
+environment: "dev"
+
+## @section Ingress Configuration
+## Ingress configuration for OGDC API and storage endpoints
+##
+ingress:
+  ## @param ingress.enabled Enable ingress resource for OGDC
+  ## Set to false for local development
+  enabled: true
+
+  ## @param ingress.className IngressClass to use for the ingress resource
+  className: "nginx"
+
+  annotations:
+    ## @param ingress.annotations.cert-manager.io/cluster-issuer cert-manager ClusterIssuer to use for TLS certificate management
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/rewrite-target Rewrite target for nginx ingress
+    ## @param ingress.annotations.nginx.ingress.kubernetes.io/use-regex Use regex for nginx ingress paths
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+
+  tls:
+    ## @param ingress.tls.enabled Enable TLS for ingress
+    ## @param ingress.tls.secretName Name of the secret containing TLS certificate
+    enabled: true
+    secretName: "ingress-nginx-tls-cert"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -341,7 +341,7 @@ dataone_node_url: "https://arcticdata.io/metacat/d1/mn"
 ogdc_public_host: "api.test.dataone.org"
 
 ## @param internal_s3_endpoint_url Internal S3 endpoint URL for MinIO service
-## This is the URL at which the s3 service is exposed at (cluster-internal)
+## This is the URL at which the s3 service is exposed within the cluster.
 ##
 internal_s3_endpoint_url: "http://qgnet-ogdc-minio:9000"
 


### PR DESCRIPTION
Updates to ingress for dev deployment. Changes include:

1. Update ingress `pathType: Prefix` instead of `pathType: ImplementationSpecific` (recommended)
2. Disables and removes `Argo Workflows > Server` specific ingress from the sub-chart. When we decide to expose the Argo server, we can add a new entry to existing ingress template.
3. Adds resource limits to base ogdc-runner