### PR TITLE
Minor updates based on work over in ogdc-runner

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -122,11 +122,8 @@ Refer to the [getting started](https://github.com/QGreenland-Net/ogdc-helm?tab=r
 
 | Name                        | Description                                           | Value                                                                                              |
 | --------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `image.repository`          | OGDC container image repository                       | `ogdc-runner`                                                                                      |
-| `image.tag`                 | OGDC container image tag                              | `latest`                                                                                           |
-| `image.pullPolicy`          | OGDC container image pull policy                      | `IfNotPresent`                                                                                     |
-| `environment`               | Deployment environment name (local, dev, prod)        | `""`                                                                                               |
-| `access_mode`               | Access mode (authenticated, read-only, open)          | `authenticated`                                                                                    |
+| `auth.accessMode`           | Access mode (authenticated, read-only, open)          | `authenticated`                                                                                    |
+| `auth.roleName.admin`       | Scope name for the admin role                         | `ogdc:admin`                                                                                       |
 | `resources.requests.memory` | Memory requests for OGDC service                      | `1Gi`                                                                                              |
 | `resources.requests.cpu`    | CPU requests for OGDC service                         | `500m`                                                                                             |
 | `resources.limits.memory`   | Memory limits for OGDC service                        | `2Gi`                                                                                              |

--- a/helm/admin/secrets.yaml
+++ b/helm/admin/secrets.yaml
@@ -93,7 +93,7 @@ stringData:
   OGDC_ADMIN_PASSWORD: "password"
   # to get a string like this run:
   # openssl rand -hex 32
-  OGDC_JWT_SECRET_KEY: "<run: openssl rand -hex 32>"
+  OGDC_SECRET_KEY: "<run: openssl rand -hex 32>"
 
 ## @param data
 ## Contains the secret data. The serialized form of the secret data is a base64 encoded string,

--- a/helm/admin/secrets.yaml
+++ b/helm/admin/secrets.yaml
@@ -88,9 +88,6 @@ type: Opaque
 ## # # #    NEVER CHECK SECRETS INTO GITHUB!   # # #
 ##
 stringData:
-  # Change these values to your desired passwords
-  # This value used as the password for the API admin user
-  OGDC_ADMIN_PASSWORD: "password"
   # to get a string like this run:
   # openssl rand -hex 32
   OGDC_SECRET_KEY: "<run: openssl rand -hex 32>"

--- a/helm/examples/values-local-cluster-ogdc-example.yaml
+++ b/helm/examples/values-local-cluster-ogdc-example.yaml
@@ -170,4 +170,6 @@ ogdc_s3_endpoint: "http://${RELEASE_NAME}-minio:9000"
 ogdc_public_s3_url: "https://localhost:7443/storage"
 ogdc_workflow_pvc_name: "cephfs-${RELEASE_NAME}-workflow-pvc"
 ogdc_viz_workflow_image: "ghcr.io/permafrostdiscoverygateway/viz-workflow:1.1.0-dev-2"
-access_mode: "open"
+
+auth:
+  accessMode: "open"

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -26,4 +26,5 @@ data:
   {{- end }}
   VIZ_WORKFLOW_DEFAULT_PARTITION_SIZE: {{ .Values.viz_workflow.default_partition_size | quote }}
   VIZ_WORKFLOW_RESOURCES: {{ .Values.viz_workflow.resources | toJson | quote }}
-  ACCESS_MODE: {{ .Values.access_mode | quote }}
+  ACCESS_MODE: {{ .Values.auth.accessMode | quote }}
+  OGDC_SCOPE_ADMIN: {{ .Values.auth.roleName.admin | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -356,7 +356,7 @@ resources:
 ## @param ogdc_service_command Command to start the OGDC FastAPI service
 ## Default to production fastapi run command
 ##
-ogdc_service_command: ". ./.venv/bin/activate && fastapi run --port 8000 --host 0.0.0.0 src/ogdc_runner/service/main.py"
+ogdc_service_command: ". ./.venv/bin/activate && fastapi run --port 8000 --host 0.0.0.0 --forwarded-allow-ips='*' src/ogdc_runner/service/main.py"
 
 ## @param dataone_node_url DataONE member node URL for metadata retrieval
 dataone_node_url: "https://arcticdata.io/metacat/d1/mn"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -329,10 +329,17 @@ image:
 ##
 environment: ""
 
-## @param access_mode Access mode (authenticated, read-only, open)
-## Injected into the ogdc-service pod as the ACCESS_MODE env var, which is used by
-## the dataone.auth python library to determine access.
-access_mode: "authenticated"
+
+## @section API Access - Authentication and Authorization
+##
+auth:
+  ## @param auth.accessMode Access mode (authenticated, read-only, open)
+  ## Injected into the ogdc-service pod as the ACCESS_MODE env var, which is used by
+  ## the dataone.auth python library to determine access.
+  accessMode: "authenticated"
+  ## @param auth.roleName.admin Scope name for the admin role
+  roleName:
+    admin: "ogdc:admin"
 
 ## @param resources.requests.memory Memory requests for OGDC service
 ## @param resources.requests.cpu CPU requests for OGDC service


### PR DESCRIPTION
This allows us to configure the scopes via helm chart, and changes the name of the secret used to authenticate user sessions