### PR TITLE
Feat 83 pvc inputs

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -136,8 +136,19 @@ Refer to the [getting started](https://github.com/QGreenland-Net/ogdc-helm?tab=r
 | `ogdc_public_host`          | Public host (no scheme, no path) for external access. | `api.test.dataone.org`                                                                             |
 | `ogdc_public_s3_url`        | Public S3 endpoint URL for external access.           | `""`                                                                                               |
 | `ogdc_workflow_pvc_name`    | Name of the PVC to use for workflow storage.          | `cephfs-qgnet-ogdc-workflow-pvc`                                                                   |
+| `ogdc_input_pvcs`           | Allowlist of pre-provisioned PVCs recipes may mount.  | `[]`                                                                                               |
 | `ogdc_max_parallel_limit`   | Maximum number of parallel workflow tasks.            | `5`                                                                                                |
 | `ogdc_viz_workflow_image`   | Container image used for visualization workflow pods. | `ghcr.io/permafrostdiscoverygateway/viz-workflow:latest`                                           |
+
+`ogdc_input_pvcs` is rendered into the OGDC service as `OGDC_ALLOWED_INPUT_PVCS`.
+Recipe `pvc_mount` inputs are rejected unless their `claim_name` matches one of
+the configured `claimName` values:
+
+```yaml
+ogdc_input_pvcs:
+  - claimName: cephfs-qgnet-ogdc-adc-tiles-pvc
+    description: ADC Tile Store PVC
+```
 
 ### OGDC Workflow Runtime Configuration
 

--- a/helm/examples/values-dev-cluster-ogdc-example.yaml
+++ b/helm/examples/values-dev-cluster-ogdc-example.yaml
@@ -142,4 +142,7 @@ ogdc_public_host: "api.test.dataone.org"
 ogdc_s3_endpoint: "http://${RELEASE_NAME}-minio:9000"
 ogdc_public_s3_url: "https://api.test.dataone.org/ogdc/storage"
 ogdc_workflow_pvc_name: "cephfs-${RELEASE_NAME}-workflow-pvc"
+ogdc_input_pvcs:
+  - claimName: "cephfs-${RELEASE_NAME}-adc-tiles-pvc"
+    description: "ADC Tile Store PVC"
 ogdc_viz_workflow_image: "ghcr.io/permafrostdiscoverygateway/viz-workflow:latest"

--- a/helm/examples/values-local-cluster-ogdc-example.yaml
+++ b/helm/examples/values-local-cluster-ogdc-example.yaml
@@ -118,4 +118,7 @@ ogdc_public_host: "localhost"
 ogdc_s3_endpoint: "http://${RELEASE_NAME}-minio:9000"
 ogdc_public_s3_url: "https://localhost:7443/ogdc/storage"
 ogdc_workflow_pvc_name: "cephfs-${RELEASE_NAME}-workflow-pvc"
+ogdc_input_pvcs:
+  - claimName: "ogdc-test-pvc"
+    description: "Local test input data PVC"
 ogdc_viz_workflow_image: "ghcr.io/permafrostdiscoverygateway/viz-workflow:latest"

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
   OGDC_DB_HOST: "{{ .Release.Name }}-db-cnpg-rw"
   OGDC_DB_NAME: "ogdc"
   OGDC_WORKFLOW_PVC_NAME: {{ .Values.ogdc_workflow_pvc_name | quote }}
+  OGDC_ALLOWED_INPUT_PVCS: {{ .Values.ogdc_input_pvcs | default list | toJson | quote }}
   OGDC_MAX_PARALLEL_LIMIT: {{ .Values.ogdc_max_parallel_limit | quote }}
   ARGO_WORKFLOW_RETRY_ENABLED: {{ .Values.argo_workflow_retry.enabled | quote }}
   ARGO_WORKFLOW_RETRY_LIMIT: {{ .Values.argo_workflow_retry.limit | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -376,6 +376,18 @@ ogdc_public_s3_url: ""
 ##
 ogdc_workflow_pvc_name: "cephfs-qgnet-ogdc-workflow-pvc"
 
+## @param ogdc_input_pvcs Allowlist of pre-provisioned PVCs that recipes may
+## reference as `pvc_mount` inputs.
+## Injected into the ogdc-service pod as `OGDC_ALLOWED_INPUT_PVCS`.
+## Leave empty to reject all recipe input PVC claims.
+##
+## Example:
+## ogdc_input_pvcs:
+##   - claimName: cephfs-qgnet-ogdc-adc-tiles-pvc
+##     description: ADC Tile Store PVC
+##
+ogdc_input_pvcs: []
+
 ## @param ogdc_max_parallel_limit Maximum number of parallel workflow tasks.
 ## Injected into the ogdc-service pod as `OGDC_MAX_PARALLEL_LIMIT`.
 ##

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -337,7 +337,7 @@ resources:
   requests:
     memory: "1Gi"
     cpu: "500m"
-  limits: 
+  limits:
     memory: "2Gi"
     cpu: "1000m"
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -64,6 +64,9 @@ deploy:
             existingSecret: "qgnet-ogdc-secrets"
           ogdc_s3_endpoint: "http://qgnet-ogdc-minio:9000"
           ogdc_workflow_pvc_name: "cephfs-qgnet-ogdc-workflow-pvc"
+          ogdc_input_pvcs:
+            - claimName: "ogdc-test-pvc"
+              description: "Local test input data PVC"
           ogdc_public_s3_url: "https://localhost:7443/ogdc/storage"
 portForward:
   # Expose ogdc-runner API at port 8000


### PR DESCRIPTION
Adds a pre-configured PVC allow list for OGDC to access datasets (could be any K8s PV access mode - RO/ROX/RWO/RWX/...).

This goes along with the OGDC-runner support added at [ogdc-runner#164](https://github.com/QGreenland-Net/ogdc-runner/pull/164) for parallel PVC inputs. And example recipe can be found at [ogdc-recipes#15](https://github.com/QGreenland-Net/ogdc-recipes/pull/15)